### PR TITLE
Fix timing issues waiting for scala-cli linking

### DIFF
--- a/project/src/hasher.scala
+++ b/project/src/hasher.scala
@@ -1,15 +1,11 @@
-import java.security.MessageDigest
-
 import cats.effect.IO
+import fs2.io.file.*
 
-val md = MessageDigest.getInstance("MD5")
+// TODO: Use last modified time once scala-cli stops
+//       copy pasting the files from a temporary directory
+//       and performs linking in place
+// def fileHash(filePath: Path): IO[String] =
+//   Files[IO].getLastModifiedTime(filePath).map(_.toNanos.toString)
 
-def fielHash(filePath: fs2.io.file.Path): IO[String] =
-  fs2
-    .io
-    .file
-    .Files[IO]
-    .readUtf8Lines(filePath)
-    .compile
-    .toList
-    .map(lines => md.digest(lines.mkString("\n").getBytes).map("%02x".format(_)).mkString)
+def fileHash(filePath: fs2.io.file.Path): IO[String] =
+  Files[IO].readAll(filePath).through(fs2.hash.md5).through(fs2.text.hex.encode).compile.string


### PR DESCRIPTION
Before there were two concurrent proesses
- one was publishing a browser refresh signal when linking was done
- one was watching the file-system for changes and checking updating the map of hashes The problem is that sometimes the event for changed file comes after linking has finished, creating an issue

Now linking publishes an event in `linkingTopic`.
`fileWatcher` waits reacts to events in `linkingTopic` by listing all files in the directory, calculating the hash and then publishing an event in `refreshTopic` which refreshes the browser