### PR TITLE
Remove dependency from os-lib in main

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -28,7 +28,6 @@ object project extends ScalaModule with PublishModule with FormatFix /*with Scal
     ivy"com.lihaoyi::scalatags::0.12.0",
     ivy"com.monovore::decline::2.4.1",
     ivy"com.monovore::decline-effect::2.4.1",
-    ivy"com.lihaoyi::os-lib:0.10.1",
     ivy"io.circe::circe-yaml::0.15.1",
     ivy"com.outr::scribe-cats::3.13.5"
   )
@@ -43,7 +42,8 @@ object project extends ScalaModule with PublishModule with FormatFix /*with Scal
       ivy"com.microsoft.playwright:playwright:${playwrightVersion.pwV}",
       ivy"com.microsoft.playwright:driver-bundle:${playwrightVersion.pwV}",
       ivy"org.typelevel::munit-cats-effect::2.0.0-M1",
-      ivy"com.lihaoyi::requests::0.8.2"
+      ivy"com.lihaoyi::requests::0.8.2",
+      ivy"com.lihaoyi::os-lib:0.10.1"
     )
   }
 

--- a/project/src/routes.scala
+++ b/project/src/routes.scala
@@ -109,20 +109,16 @@ def routes(
 
   val staticAssetRoutes: HttpRoutes[IO] = indexOpts match
     case None => generatedIndexHtml(injectStyles = false)
-    case Some(IndexHtmlConfig(Some(externalPath), None)) =>
+    case Some(IndexHtmlConfig.IndexHtmlPath(externalPath)) =>
       Router(
         "" -> fileService[IO](FileService.Config(externalPath.toString()))
       )
-    case Some(IndexHtmlConfig(None, Some(stylesPath))) =>
+    case Some(IndexHtmlConfig.StylesOnly(stylesPath)) =>
       generatedIndexHtml(injectStyles = true).combineK(
         Router(
           "" -> fileService[IO](FileService.Config(stylesPath.toString()))
         )
       )
-    case _ =>
-      throw new Exception(
-        "A seperate style path and index.html location were defined, this is not permissable"
-      ) // This should have been validated out earlier
 
   val refreshRoutes = HttpRoutes.of[IO] {
     // case GET -> Root / "all" =>

--- a/project/test/src/RoutesSpec.scala
+++ b/project/test/src/RoutesSpec.scala
@@ -166,7 +166,7 @@ class RoutesSuite extends CatsEffectSuite:
           theseRoutes <- routes(
             appDir.toString,
             refreshPub,
-            Some(IndexHtmlConfig(Some(staticDir), None)),
+            Some(IndexHtmlConfig.IndexHtmlPath(staticDir.toFs2)),
             HttpRoutes.empty[IO],
             fileToHashRef
           )(logger)
@@ -225,7 +225,7 @@ class RoutesSuite extends CatsEffectSuite:
           theseRoutes <- routes(
             appDir.toString,
             refreshPub,
-            Some(IndexHtmlConfig(None, Some(styleDir))),
+            Some(IndexHtmlConfig.StylesOnly(styleDir.toFs2)),
             HttpRoutes.empty[IO],
             fileToHashRef
           )(logger)


### PR DESCRIPTION
We already depend on fs2, so having two file system libraries seems redundant.
Unfortunately, using `IO` you can't use `.validate` anymore to check for paths.
So I raise a special exception which is then handled by printing the error and the help message as decline does by default for `.validate`. I can't use `CommandIOApp` since otherwise I can't access the help message anymore (this could be an issue to be raised to them)

Fixes https://github.com/Quafadas/live-server-scala-cli-js/issues/13