### PR TITLE
Fix typo in error message (index.html should be index.less)

### DIFF
--- a/project/src/live.server.scala
+++ b/project/src/live.server.scala
@@ -260,7 +260,7 @@ object LiveServer extends IOApp:
           val indexLessFile = styles / "index.less"
           (for
             indexLessExists <- Files[IO].exists(indexLessFile)
-            _ <- IO.raiseUnless(indexLessExists)(CliValidationError(s"index.html doesn't exist in $styles"))
+            _ <- IO.raiseUnless(indexLessExists)(CliValidationError(s"index.less doesn't exist in $styles"))
             indexLessIsAFile <- Files[IO].isRegularFile(indexLessFile)
             _ <- IO.raiseUnless(indexLessIsAFile)(CliValidationError(s"$indexLessFile is not a file"))
           yield IndexHtmlConfig.StylesOnly(styles).some).toResource


### PR DESCRIPTION
Fixes a small issue in the error message when `index.less` is missing, which was particularly confusing